### PR TITLE
Added ${CMAKE_CFG_INTDIR} to fix IDE generator builds

### DIFF
--- a/cmake/modules/cpp_resource.cmake
+++ b/cmake/modules/cpp_resource.cmake
@@ -5,13 +5,13 @@ function(find_resource_compiler)
   if(NOT (COMMAND cpp_rsc))
     include(ExternalProject)
     ExternalProject_Add(cpp_rsc_prj
-                        GIT_REPOSITORY https://github.com/orex/cpp_rsc.git
+                        GIT_REPOSITORY https://github.com/headupinclouds/cpp_rsc.git
                         GIT_TAG master
                         INSTALL_COMMAND "")
     
     
     get_property(RSC_BIN_FOLDER TARGET cpp_rsc_prj PROPERTY _EP_BINARY_DIR)
-    set_property(GLOBAL PROPERTY CPPRSC_CMD ${RSC_BIN_FOLDER}/src/cpp_rsc)
+    set_property(GLOBAL PROPERTY CPPRSC_CMD ${RSC_BIN_FOLDER}/src/${CMAKE_CFG_INTDIR}/cpp_rsc)
   else() 
     set_property(GLOBAL PROPERTY CPPRSC_CMD cpp_rsc)
   endif()

--- a/src/rsc_create_files.h
+++ b/src/rsc_create_files.h
@@ -133,7 +133,7 @@ void rsc_create_files::write_variable_def(std::ostream &os, const rsc_item &item
 {
   using namespace std;
   os << "  /* Variable " + item.var_name + " from file " + item.file_path + " */\n" +
-        "  " + (header ? "extern ": "") + "const unsigned char " + item.var_name + "[]" + (header ? ";": " = ")
+        "  " + (header ? "extern ": "") + "const char " + item.var_name + "[]" + (header ? ";": " = ")
      << endl;
   
   if(header)

--- a/src/rsc_create_files.h
+++ b/src/rsc_create_files.h
@@ -133,7 +133,7 @@ void rsc_create_files::write_variable_def(std::ostream &os, const rsc_item &item
 {
   using namespace std;
   os << "  /* Variable " + item.var_name + " from file " + item.file_path + " */\n" +
-        "  " + (header ? "extern ": "") + "const char " + item.var_name + "[]" + (header ? ";": " = ")
+        "  " + (header ? "extern ": "") + "const unsigned char " + item.var_name + "[]" + (header ? ";": " = ")
      << endl;
   
   if(header)


### PR DESCRIPTION
Reverted the global const char [] to unsigned const char [] change per discussion on previous pull request. 

Preserved the ${CMAKE_CFG_INTDIR} path mod for IDE builds.
